### PR TITLE
Allow setting a custom # of OpenCV threads

### DIFF
--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -970,18 +970,11 @@ public:
   static const int ORIENTATION_LEFTBOTTOM = 8;
 
   Photon_OpenCV() {
-    // Lower default # of threads to ceil( Cores / 4 )
-    cv::setNumThreads( ceil( cv::getNumberOfCPUs() / 4 ) );
+    cv::setNumThreads(Php::ini_get("photon.opencv_threads"));
+
     /* Static local intilization is thread safe */
     static std::once_flag initialized;
     std::call_once(initialized, _initialize);
-  }
-
-  void setopencvnumthreads(Php::Parameters &params) {
-      if ( params.empty() ) {
-           return;
-      }
-      cv::setNumThreads( params[0] );
   }
 
   void readimageblob(Php::Parameters &params) {
@@ -1436,7 +1429,6 @@ extern "C" {
     photon_opencv.constant("ORIENTATION_LEFTBOTTOM",
         Photon_OpenCV::ORIENTATION_LEFTBOTTOM);
 
-    photon_opencv.method<&Photon_OpenCV::setopencvnumthreads>("setopencvnumthreads");
     photon_opencv.method<&Photon_OpenCV::readimageblob>("readimageblob", {
       Php::ByRef("raw_image_data", Php::Type::String),
     });
@@ -1524,6 +1516,9 @@ extern "C" {
     });
 
     extension.add(std::move(photon_opencv));
+
+    // Default to 2 if not set
+    extension.add(Php::Ini("photon.opencv_threads", 2));
 
     return extension;
   }

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -1385,7 +1385,7 @@ cmsHPROFILE Photon_OpenCV::_srgb_profile = nullptr;
 
 extern "C" {
   PHPCPP_EXPORT void *get_module() {
-    static Php::Extension extension("photon-opencv", "0.2.27");
+    static Php::Extension extension("photon-opencv", "0.2.28");
 
     Php::Class<Photon_OpenCV> photon_opencv("Photon_OpenCV");
 

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -970,6 +970,11 @@ public:
   static const int ORIENTATION_LEFTBOTTOM = 8;
 
   Photon_OpenCV() {
+    int opencv_threads = 2;
+    if ( Php::SERVER["PHOTON_OPENCV_THREADS"] ) {
+        opencv_threads = Php::SERVER["PHOTON_OPENCV_THREADS"];
+    }
+    cv::setNumThreads( opencv_threads );
     /* Static local intilization is thread safe */
     static std::once_flag initialized;
     std::call_once(initialized, _initialize);


### PR DESCRIPTION
Add an INI directive to change the # of allowed OpenCV threads. Default lowered to 2 if nothing set.

### Testing Instructions

- Build extension.
- Grab https://upload.wikimedia.org/wikipedia/commons/9/9d/Wikidata_Map_July_2017_Huge.png
- Create a test file `/tmp/test.php`:
```
<?php

for ( $i = 0; $i < 100; $i++ ) {
	$photon = new Photon_OpenCV();
	$photon->readimageblob( file_get_contents( '/tmp/Wikidata_Map_July_2017_Huge.png' ) );
	$photon->setimageformat( 'webp' );
	$photon->resizeimage( 500, 500 );
	$photon->writeimage( '/tmp/output.webp' );
}
```
- `{PHP_EXECUTABLE} -dphoton.opencv_threads=4 -dextension={$PATH_TO_EXTENSIONS}/photon-opencv.so /tmp/test.php`
- Check # of threads, e.g. `ps -eLf | grep php`

## Notes
```
photon.opencv_threads > 0 sets the number of threads
photon.opencv_threads == 0 disables threads
photon.opencv_threads == -1 restores old default (# of threads set to # of cores)
```