### PR TITLE
Use svt as AVIF encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/msf_gif.h
+**.o
+**.so

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -1,16 +1,12 @@
 #include <opencv2/opencv.hpp>
 #include <gif_lib.h>
 #include <libheif/heif.h>
-#include <cstdlib>
-
 #include "gif-palette.h"
 #include "frame.h"
 #include "encoder.h"
 #include "libheif-encoder.h"
 
-void Libheif_Encoder::_initialize() {
-  // setenv("SVT_LOG", "1", 1); // Errors only
-  
+void Libheif_Encoder::_initialize() {  
  std::unique_ptr<heif_context, decltype(&heif_context_free)> context(
    heif_context_alloc(), &heif_context_free);
 

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -9,7 +9,7 @@
 #include "libheif-encoder.h"
 
 void Libheif_Encoder::_initialize() {
-  setenv("SVT_LOG", "1", 1); // Errors only
+  // setenv("SVT_LOG", "1", 1); // Errors only
   
  std::unique_ptr<heif_context, decltype(&heif_context_free)> context(
    heif_context_alloc(), &heif_context_free);
@@ -88,7 +88,6 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
     decltype(&heif_nclx_color_profile_free)>
     nclx(nullptr, &heif_nclx_color_profile_free);
 
-  // `threads` actually sets LevelOfParallelism param of SVT (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md#1-thread-management-parameters)
   heif_encoder_set_parameter(encoder.get(), "threads", std::to_string(_thread_count).c_str());
 
   auto lossless_option = _options->find(_format + ":lossless");

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -24,7 +24,8 @@ void Libheif_Encoder::_initialize() {
 Libheif_Encoder::Libheif_Encoder(const std::string &format,
     int quality,
     const std::map<std::string, std::string> *options,
-    std::vector<uint8_t> *output) {
+    std::vector<uint8_t> *output,
+    int thread_count) {
   /* Static local intilization is thread safe */
   static std::once_flag initialized;
   std::call_once(initialized, _initialize);
@@ -33,6 +34,7 @@ Libheif_Encoder::Libheif_Encoder(const std::string &format,
   _quality = quality;
   _format = format;
   _output = output;
+  _thread_count = thread_count;
 
   _output->clear();
 }
@@ -82,6 +84,9 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
   std::unique_ptr<heif_color_profile_nclx,
     decltype(&heif_nclx_color_profile_free)>
     nclx(nullptr, &heif_nclx_color_profile_free);
+
+  // `threads` set LevelOfParallelism param of SVT (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md#1-thread-management-parameters)
+  heif_encoder_set_parameter(encoder.get(), "threads", std::to_string(_thread_count).c_str());
 
   auto lossless_option = _options->find(_format + ":lossless");
   if (lossless_option != _options->end()

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -6,7 +6,7 @@
 #include "encoder.h"
 #include "libheif-encoder.h"
 
-void Libheif_Encoder::_initialize() {  
+void Libheif_Encoder::_initialize() {
  std::unique_ptr<heif_context, decltype(&heif_context_free)> context(
    heif_context_alloc(), &heif_context_free);
 
@@ -60,7 +60,7 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
     &heif_encoder_release);
   heif_encoder *raw_encoder;
 
-  // Force pick AOM for AVIF images, as it supports lossless encoding
+  // Force pick SVT for AVIF images
   if (heif_compression_AV1 == heif_format) {
     error = heif_context_get_encoder(context.get(),
         _svt_descriptor,
@@ -84,13 +84,18 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
     decltype(&heif_nclx_color_profile_free)>
     nclx(nullptr, &heif_nclx_color_profile_free);
 
+  // Setting "threads" on libheif configures LevelOfParallelism in SVT
   heif_encoder_set_parameter(encoder.get(), "threads", std::to_string(_thread_count).c_str());
 
   auto lossless_option = _options->find(_format + ":lossless");
   if (lossless_option != _options->end()
       && "true" == lossless_option->second) {
     heif_encoder_set_lossless(encoder.get(), 1);
-
+    
+    // SVT currently does not support 444 chroma subsampling - https://gitlab.com/AOMediaCodec/SVT-AV1/-/issues/2211
+    // heif_encoder_set_parameter(encoder.get(), "chroma", "444");
+    // nclx->matrix_coefficients = heif_matrix_coefficients_RGB_GBR;
+    
     nclx.reset(heif_nclx_color_profile_alloc());
     nclx->transfer_characteristics =
       heif_transfer_characteristic_unspecified;

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -13,8 +13,8 @@ void Libheif_Encoder::_initialize() {
 
  if (!heif_context_get_encoder_descriptors(context.get(),
      heif_compression_AV1,
-     "aom",
-     &_aom_descriptor,
+     "svt",
+     &_svt_descriptor,
      1)) {
    throw std::runtime_error("AOM encoder for AVIF images not available");
  }
@@ -62,7 +62,7 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
   // Force pick AOM for AVIF images, as it supports lossless encoding
   if (heif_compression_AV1 == heif_format) {
     error = heif_context_get_encoder(context.get(),
-        _aom_descriptor,
+        _svt_descriptor,
         &raw_encoder);
   }
   else {
@@ -210,4 +210,4 @@ bool Libheif_Encoder::finalize() {
   return true;
 }
 
-const heif_encoder_descriptor *Libheif_Encoder::_aom_descriptor = nullptr;
+const heif_encoder_descriptor *Libheif_Encoder::_svt_descriptor = nullptr;

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -1,6 +1,7 @@
 #include <opencv2/opencv.hpp>
 #include <gif_lib.h>
 #include <libheif/heif.h>
+#include <cstdlib>
 
 #include "gif-palette.h"
 #include "frame.h"
@@ -8,6 +9,8 @@
 #include "libheif-encoder.h"
 
 void Libheif_Encoder::_initialize() {
+  setenv("SVT_LOG", "1", 1); // Errors only
+  
  std::unique_ptr<heif_context, decltype(&heif_context_free)> context(
    heif_context_alloc(), &heif_context_free);
 
@@ -85,7 +88,7 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
     decltype(&heif_nclx_color_profile_free)>
     nclx(nullptr, &heif_nclx_color_profile_free);
 
-  // `threads` set LevelOfParallelism param of SVT (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md#1-thread-management-parameters)
+  // `threads` actually sets LevelOfParallelism param of SVT (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md#1-thread-management-parameters)
   heif_encoder_set_parameter(encoder.get(), "threads", std::to_string(_thread_count).c_str());
 
   auto lossless_option = _options->find(_format + ":lossless");

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -165,7 +165,8 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
       options.get(),
       nullptr);
   if (error.code != heif_error_Ok) {
-    _last_error = "Failed to encode image";
+    _last_error = "Failed to encode image: ";
+    _last_error += error.message;
     return false;
   }
 

--- a/libheif-encoder.cpp
+++ b/libheif-encoder.cpp
@@ -87,11 +87,8 @@ bool Libheif_Encoder::add_frame(const Frame &frame) {
   if (lossless_option != _options->end()
       && "true" == lossless_option->second) {
     heif_encoder_set_lossless(encoder.get(), 1);
-    heif_encoder_set_parameter(encoder.get(), "chroma", "444");
 
     nclx.reset(heif_nclx_color_profile_alloc());
-    // Only set version 1 fields
-    nclx->matrix_coefficients = heif_matrix_coefficients_RGB_GBR;
     nclx->transfer_characteristics =
       heif_transfer_characteristic_unspecified;
     nclx->color_primaries = heif_color_primaries_unspecified;

--- a/libheif-encoder.h
+++ b/libheif-encoder.h
@@ -4,6 +4,7 @@ protected:
   std::string _format;
   int _quality;
   std::vector<uint8_t> *_output;
+  int _thread_count;
   static const heif_encoder_descriptor *_svt_descriptor;
 
   static void _initialize();
@@ -12,7 +13,8 @@ public:
   Libheif_Encoder(const std::string &format,
       int quality,
       const std::map<std::string, std::string> *options,
-      std::vector<uint8_t> *output);
+      std::vector<uint8_t> *output,
+      int thread_count = 2);
   bool add_frame(const Frame &frame);
   bool finalize();
 };

--- a/libheif-encoder.h
+++ b/libheif-encoder.h
@@ -4,7 +4,7 @@ protected:
   std::string _format;
   int _quality;
   std::vector<uint8_t> *_output;
-  static const heif_encoder_descriptor *_aom_descriptor;
+  static const heif_encoder_descriptor *_svt_descriptor;
 
   static void _initialize();
   

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -1,6 +1,7 @@
 #include <phpcpp.h>
 #include <string>
 #include <cstdio>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <map>
@@ -1145,6 +1146,8 @@ public:
 
   Photon_OpenCV() {
     cv::setNumThreads(Php::ini_get("photon.opencv_threads"));
+    int svt_log_level = Php::ini_get("photon.svt_log_level");
+    setenv("SVT_LOG", std::to_string(svt_log_level).c_str(), 1);
 
     /* Static local intilization is thread safe */
     static std::once_flag initialized;
@@ -1748,6 +1751,8 @@ extern "C" {
     extension.add(Php::Ini("photon.opencv_threads", 2));
     // Controls degree of parallelism. Range [0-6] (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Docs/Parameters.md#1-thread-management-parameters)
     extension.add(Php::Ini("photon.svt_level_of_parallelism", 2));
+    // Log level 1 -> errors (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Source/Lib/Codec/svt_log.h#L18)
+    extension.add(Php::Ini("photon.svt_log_level", 1)); 
 
     return extension;
   }

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -63,6 +63,7 @@ protected:
   std::map<std::string, std::string> _image_options;
   std::vector<std::function<void()>> _operations;
   std::unique_ptr<Decoder> _decoder;
+  int _thread_count;
   bool _preserve_palette;
   bool _first_encode;
 
@@ -805,7 +806,8 @@ protected:
             _format,
             quality,
             &_image_options,
-            &output_buffer));
+            &output_buffer,
+            _thread_count));
     }
     else if ("webp" == _format && _decoder->provides_animation()) {
       encoder.reset(new LibWebP_Full_Frame_Encoder(
@@ -1143,7 +1145,8 @@ public:
   static const int ORIENTATION_LEFTBOTTOM = 8;
 
   Photon_OpenCV() {
-    cv::setNumThreads(Php::ini_get("photon.opencv_threads"));
+    _thread_count = Php::ini_get("photon.opencv_threads");
+    cv::setNumThreads(_thread_count);
 
     /* Static local intilization is thread safe */
     static std::once_flag initialized;

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -63,7 +63,6 @@ protected:
   std::map<std::string, std::string> _image_options;
   std::vector<std::function<void()>> _operations;
   std::unique_ptr<Decoder> _decoder;
-  int _thread_count;
   bool _preserve_palette;
   bool _first_encode;
 
@@ -807,7 +806,7 @@ protected:
             quality,
             &_image_options,
             &output_buffer,
-            _thread_count));
+            Php::ini_get("photon.svt_level_of_parallelism")));
     }
     else if ("webp" == _format && _decoder->provides_animation()) {
       encoder.reset(new LibWebP_Full_Frame_Encoder(
@@ -1145,8 +1144,7 @@ public:
   static const int ORIENTATION_LEFTBOTTOM = 8;
 
   Photon_OpenCV() {
-    _thread_count = Php::ini_get("photon.opencv_threads");
-    cv::setNumThreads(_thread_count);
+    cv::setNumThreads(Php::ini_get("photon.opencv_threads"));
 
     /* Static local intilization is thread safe */
     static std::once_flag initialized;
@@ -1748,6 +1746,8 @@ extern "C" {
 
     // Default to 2 if not set
     extension.add(Php::Ini("photon.opencv_threads", 2));
+    // Controls degree of parallelism. Range [0-6] (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Docs/Parameters.md#1-thread-management-parameters)
+    extension.add(Php::Ini("photon.svt_level_of_parallelism", 2));
 
     return extension;
   }

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -1751,7 +1751,7 @@ extern "C" {
     extension.add(Php::Ini("photon.opencv_threads", 2));
     // Controls degree of parallelism. Range [0-6] (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Docs/Parameters.md#1-thread-management-parameters)
     extension.add(Php::Ini("photon.svt_level_of_parallelism", 2));
-    // Log level 1 -> errors (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Source/Lib/Codec/svt_log.h#L18)
+    // Log level 1 is errors + fatals (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Source/Lib/Codec/svt_log.h#L18)
     extension.add(Php::Ini("photon.svt_log_level", 1)); 
 
     return extension;


### PR DESCRIPTION
This PR changes AVIF encoder from aom to SVT-AV1 since it is faster for sync encoding. 

### Controlling thread usage of SVT

I've added a separate `photon.svt_level_of_parallelism` variable instead of reusing `photon.opencv_threads` because SVT uses a [level of parallelism](https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md?ref_type=heads#1-thread-management-parameters) abstraction (range 0-6) rather than direct thread count like OpenCV. On my 12 core laptop, `LevelOfParallelism=2` provides the best performance on average, so I've set it as the default. This is lower than the default set by libheif which is 4.

While we could map `photon.opencv_threads` to SVT levels, this would require maintaining a mapping function similar to [this implementation](https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Source/Lib/Globals/enc_handle.c#L453) adding maintenance overhead.

### Controlling SVT Log Level
SVT log level can only be controlled by [setting the SVT_LOG environment variable](https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Source/Lib/Codec/svt_log.c#L33). I've made it configurable via `photon.svt_log_level` in php.ini since the logs proved useful during debugging.

