### PR TITLE
Prevent OpenCV from logging errors for unsupported image formats

### DIFF
--- a/opencv-decoder.cpp
+++ b/opencv-decoder.cpp
@@ -25,6 +25,10 @@ void OpenCV_Decoder::reset() {
    * filesystem so that imread can be used.
   */
   TempFile temp_image_file(*_data);
+  if (!cv::haveImageReader(temp_image_file.get_path())) {
+    _ok = false;
+    return;
+  }
   int decode_flags = cv::IMREAD_UNCHANGED;
   size_t num_frames = cv::imcount(temp_image_file.get_path(), decode_flags);
   if (num_frames != 1) {


### PR DESCRIPTION
Related to #8

### Problem

When photon-opencv attempts to decode an image through OpenCV which the latter doesn't support (for example, HEIC), the following error message is logged to stdout:

```
imcount_('/tmp/somepath): can't read header or can't find decoder: OpenCV(4.9.0) /home/dinika/Downloads/software/photon/opencv-4.7.0/modules/imgcodecs/src/loadsave.cpp:1241: error: (-215:Assertion failed) m_decoder in function 'init'
```

This message is noisy, because it suggests a fatal decoding failure even though another decoder (e.g. Libheif_Decoder) may successfully handle the same image later in the decoding chain.

### Solution

In this PR I propose using [haveImageReader](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga0c3f60f18ed3a139e5a9926f9315e3bc) function (instead of simply silencing opencv logs) to completely avoid decoding the image if the format isn't supported by opencv. The impact is:
- The spurious log above won't be logged
- We won't load the image at all if opencv can't decode it. This saves a bit of RAM.


### Testing

I've tested this PR with png, jpg, heic, webp, and avif formats. I also tested that even if image has incorrect extension (eg, jpg image has .heic extension), `haveImageReader` lets the image be correctly decoded.

php script I used for testing:
```php
<?php

$image_file = 'heic-test/parrot-jpg.som';
try {
    $photon = new Photon_OpenCV();
    $photon->readimage($image_file);
    
    // Force decoding
    $photon->setimageformat( 'something' );

    $photon->setimageformat( "jpg" );
    $photon->setcompressionquality( 80 );
    $photon->writeimage( 'sample1.jpg' );
} catch (Exception $e) {
    echo "Failed: " . $e->getMessage() . "\n";
}

?>
```
