### PR TITLE
Add configurable thread count for libheif decoder

### DIFF
--- a/libheif-decoder.cpp
+++ b/libheif-decoder.cpp
@@ -7,8 +7,9 @@
 #include "decoder.h"
 #include "libheif-decoder.h"
 
-Libheif_Decoder::Libheif_Decoder(const std::string *data) {
+Libheif_Decoder::Libheif_Decoder(const std::string *data, int thread_count) {
   _data = data;
+  _thread_count = thread_count;
   reset();
 }
 
@@ -24,8 +25,8 @@ void Libheif_Decoder::reset() {
     heif_context_alloc(), &heif_context_free);
 
   heif_error error;
-  
-  heif_context_set_max_decoding_threads(context.get(), 1);
+
+  heif_context_set_max_decoding_threads(context.get(), _thread_count);
 
   error = heif_context_read_from_memory_without_copy(context.get(),
     (void *) _data->data(),
@@ -50,8 +51,8 @@ void Libheif_Decoder::reset() {
   
   std::unique_ptr<heif_decoding_options, decltype(&heif_decoding_options_free)>
   decode_options(heif_decoding_options_alloc(), &heif_decoding_options_free);
-  decode_options->num_codec_threads = 1;
-  decode_options->num_library_threads = 1;
+  decode_options->num_codec_threads = _thread_count;
+  decode_options->num_library_threads = _thread_count;
 
   std::unique_ptr<heif_image, decltype(&heif_image_release)>
     h_image(nullptr, &heif_image_release);

--- a/libheif-decoder.cpp
+++ b/libheif-decoder.cpp
@@ -24,6 +24,8 @@ void Libheif_Decoder::reset() {
     heif_context_alloc(), &heif_context_free);
 
   heif_error error;
+  
+  heif_context_set_max_decoding_threads(context.get(), 1);
 
   error = heif_context_read_from_memory_without_copy(context.get(),
     (void *) _data->data(),
@@ -45,6 +47,11 @@ void Libheif_Decoder::reset() {
   }
 
   bool has_alpha = heif_image_handle_has_alpha_channel(handle.get());
+  
+  std::unique_ptr<heif_decoding_options, decltype(&heif_decoding_options_free)>
+  decode_options(heif_decoding_options_alloc(), &heif_decoding_options_free);
+  decode_options->num_codec_threads = 1;
+  decode_options->num_library_threads = 1;
 
   std::unique_ptr<heif_image, decltype(&heif_image_release)>
     h_image(nullptr, &heif_image_release);
@@ -53,7 +60,7 @@ void Libheif_Decoder::reset() {
     &raw_h_image,
     heif_colorspace_RGB,
     has_alpha? heif_chroma_interleaved_RGBA : heif_chroma_interleaved_RGB,
-    nullptr);
+    decode_options.get());
   h_image.reset(raw_h_image);
   if (error.code) {
     return;

--- a/libheif-decoder.h
+++ b/libheif-decoder.h
@@ -4,9 +4,10 @@ protected:
   cv::Mat _frame;
   bool _ok;
   std::vector<uint8_t> _icc_profile;
+  int _thread_count;
   
 public:
-  Libheif_Decoder(const std::string *data);
+  Libheif_Decoder(const std::string *data, int thread_count = 1);
   bool loaded();
   void reset();
   bool get_next_frame(Frame &dst);

--- a/photon-opencv.cpp
+++ b/photon-opencv.cpp
@@ -387,7 +387,7 @@ protected:
       _decoder.reset(new LibWebP_Decoder(&_raw_image_data));
     }
     if (!_decoder->loaded()) {
-      _decoder.reset(new Libheif_Decoder(&_raw_image_data));
+      _decoder.reset(new Libheif_Decoder(&_raw_image_data, Php::ini_get("photon.libheif_decoder_threads")));
     }
 
     if (!_decoder->loaded()) {
@@ -1753,7 +1753,8 @@ extern "C" {
     extension.add(Php::Ini("photon.svt_level_of_parallelism", 2));
     // Log level 1 is errors + fatals (https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/v3.0.0/Source/Lib/Codec/svt_log.h#L18)
     extension.add(Php::Ini("photon.svt_log_level", 1)); 
-
+    // Controls degree of parallelism for libheif decoder. Range [0-cpu_count]. 0 means use all available threads.
+    extension.add(Php::Ini("photon.libheif_decoder_threads", 1));
     return extension;
   }
 }


### PR DESCRIPTION
## Summary

Adds a new PHP ini setting `photon.libheif_decoder_threads` to control the number of threads used when decoding images with libheif.

## Testing

Verified CPU usage changes with different thread counts when decoding AVIF:
```php
<?php
$image_path = $argv[1];

$img = new Photon_OpenCV();
$img->readimage($image_path);
$img->getimageblob();
```

Using 0 (all threads):
```
$ /usr/bin/time -f %P php -d "photon.libheif_decoder_threads=2" decode-avif.php test.avif 
128%
```

Using 1 thread (default value):
```
$ /usr/bin/time -f %P php decode-avif.php test.avif
98%
```

Using 2 threads:
```
$ /usr/bin/time -f %P php -d "photon.libheif_decoder_threads=2" decode-avif.php test.avif
109%
```